### PR TITLE
Service configuration passed to constructor

### DIFF
--- a/src/UltraLite/Container/Container.php
+++ b/src/UltraLite/Container/Container.php
@@ -17,6 +17,16 @@ class Container implements ContainerInterface
     private $delegateContainer;
 
     /**
+     * @param \Closure[] $serviceFactories
+     */
+    public function __construct(array $serviceFactories = [])
+    {
+        foreach ($serviceFactories as $serviceId => $serviceFactory) {
+            $this->set($serviceId, $serviceFactory);
+        }
+    }
+
+    /**
      * @param string $serviceId
      * @param \Closure $serviceFactory
      */

--- a/tests/phpspec/UltraLiteSpec/UltraLite/Container/ContainerSpec.php
+++ b/tests/phpspec/UltraLiteSpec/UltraLite/Container/ContainerSpec.php
@@ -63,4 +63,20 @@ class ContainerSpec extends ObjectBehavior
         // ASSERT
         $delegateContainer->get('a-dependency')->shouldHaveBeenCalled();
     }
+
+    function it_accepts_services_in_constructor()
+    {
+        // ARRANGE
+        $this->beConstructedWith([
+            'service-id' => function () {
+                return new \stdClass();
+            },
+        ]);
+
+        // ACT
+        $result = $this->get('service-id');
+
+        // ASSERT
+        $result->shouldBeLike(new \stdClass);
+    }
 }


### PR DESCRIPTION
As a developer, I don't want my application code to instantiate the container, so I want an instantiated and configured container to be returned from the container file:
```php
/** @var ContainerInterface $container */
$container = require __DIR__ . '/container.php';
```

The `container.php` file should not initialize any global variables in order to avoid any implicit dependencies on the global state including the container itself. Currently, it can be achieved like the following:
```php
return (function () : ContainerInterface {
    $services = [
        'service-id' => function () {
            return new Service();
        },
    ];

    $container = new Container();

    foreach ($services as $id => $factory) {
        $container->set($id, $factory);
    }

    return $container;
})();
```
If the `Container` class supported passing configuration to the constructor, the code above would look much cleaner:
```php
return new Container([
    'service-id' => function () {
        return new Service();
    }
]);
```
