### PR TITLE
Added some files and directory to export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/tests export-ignore


### PR DESCRIPTION
Often, `tests/` contain the code which is questionable from the security standpoint. It's a good practice to not include tests in the distribution package.